### PR TITLE
Add option to not use relative abundance in prep_mdf

### DIFF
--- a/R/color_mapping_functions.R
+++ b/R/color_mapping_functions.R
@@ -28,7 +28,8 @@
 #' # Subgroup as "Family"
 #' mdf_fam <- prep_mdf(GlobalPatterns, subgroup_level = "Family")
 prep_mdf <- function(ps,
-                     subgroup_level = "Genus")
+                     subgroup_level = "Genus",
+                     as_relative_abundance = TRUE)
     {
 
       if (!requireNamespace("phyloseq", quietly = TRUE)) {
@@ -48,10 +49,17 @@ prep_mdf <- function(ps,
       stop("'subgroup_level' does not exist")
     }
 
-    mdf <- ps %>%
+    if (as_relative_abundance==TRUE){
+      mdf <- ps %>%
         speedyseq::tax_glom(subgroup_level) %>%
         phyloseq::transform_sample_counts(function(x) { x/sum(x) }) %>%
         speedyseq::psmelt()
+    } else {
+      mdf <- ps %>%
+        speedyseq::tax_glom(subgroup_level) %>%
+        speedyseq::psmelt()
+    }
+
 
     # Removes 0 abundance
     mdf_prep <- mdf[mdf$Abundance > 0, ]


### PR DESCRIPTION
Hi microshades team,

Thanks for this awesome tool! I've been using it a lot lately for microbiome analysis, and I've started also using it with other -omics that aren't compositional. Because these other -omics (e.g. metabolomics, lipidomics) aren't compositional, I don't always want the data to be converted to relative abundances, so I created my own version of `prep_mdf()` to do so. However, I felt that this would be a good addition to the microshades, so here's this pull request :)

I added an argument to `prep_mdf()` that is `as_relative_abundance`, and it defaults to `TRUE`, so all existing code should work with no changes. The function now checks if `as_relative_abundance==TRUE`, and if so, it does the same thing it did before. If not, it simply skips the relative abundance conversion.

After making this change, all tests still passed when I ran them.

Please let me know your thoughts on this potential change, as I'd love to have an option to not use relative abundances built into microshades.

Thanks,
John