### PR TITLE
Fix coercion of logical vector into length 1 error

### DIFF
--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -39,7 +39,7 @@ plot_microshades <- function (mdf_group,
     stop("mdf_group argument must be a data frame")
   }
 
-  if(is.na(cdf$hex) || is.na(cdf$group))
+  if(sum(is.na(cdf$hex) || is.na(cdf$group)) > 0)
   {
     stop("cdf does not contain complete color information - missing hex or group info")
   }

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -39,7 +39,7 @@ plot_microshades <- function (mdf_group,
     stop("mdf_group argument must be a data frame")
   }
 
-  if(sum(is.na(cdf$hex) || is.na(cdf$group)) > 0)
+  if( (sum(is.na(cdf$hex)) > 0) || (sum(is.na(cdf$group)) > 0) )
   {
     stop("cdf does not contain complete color information - missing hex or group info")
   }


### PR DESCRIPTION
Hi microshades team,


I changed the line of code that was causing issue #21 in new versions of R. I did this by checking if the number of `NA` values in `cdf$hex` or in `cdf$group` is greater than 0 (ie, if there are any NA values in either column). Is this the way it was intended to function?

Some details of why it's erroring are in #21 .

All tests still pass, microshades still works with my old version of R, and it's resolved the issue for my labmate who does have the new version of R. Please let me know if I should alter this in any way!

Thanks,
John