### PR TITLE
Fix update-related issues

### DIFF
--- a/R/color_mapping_functions.R
+++ b/R/color_mapping_functions.R
@@ -232,10 +232,10 @@ create_color_dfs <- function(mdf,
     # Ranked abundance aggregated using sum() function
     col_name_subgroup <- paste0("Top_", subgroup_level)
     subgroup_ranks <- mdf_unknown_subgroup %>%
-        group_by_at(all_of(vars(subgroup_level, col_name_group))) %>%
+        group_by_at(c(paste(subgroup_level), paste(col_name_group))) %>%
         summarise(rank_abundance = sum(Abundance)) %>%
         arrange(desc(rank_abundance)) %>%
-        group_by_at(vars(col_name_group)) %>%
+        group_by_at(c(paste(col_name_group))) %>%
         mutate(order = row_number()) %>%
         ungroup()
 
@@ -290,7 +290,7 @@ create_color_dfs <- function(mdf,
     # https://tidyr.tidyverse.org/articles/nest.html
     # https://tidyr.tidyverse.org/reference/nest.html
     cdf <- prep_cdf %>%
-        group_by_at(all_of(vars(col_name_group))) %>%
+        group_by_at(c(paste(col_name_group))) %>%
         tidyr::nest() %>%
         arrange(!!sym(col_name_group))
 

--- a/R/color_mapping_functions.R
+++ b/R/color_mapping_functions.R
@@ -272,7 +272,7 @@ create_color_dfs <- function(mdf,
     # Get beginning of color data frame with top groups/subgroups
     # E.g., 4 selected_groups + 1 Other, 4 top_n_groups + 1 Other => 25 groups
     prep_cdf <- group_info %>%
-        select(c("group", "order", col_name_group, col_name_subgroup)) %>%
+        select(all_of(c("group", "order", col_name_group, col_name_subgroup))) %>%
         filter(order <= top_n_subgroups + 1) %>%  # "+ 1" for other subgroup
         arrange(!!sym(col_name_group), order)
 

--- a/R/color_mapping_functions.R
+++ b/R/color_mapping_functions.R
@@ -10,6 +10,7 @@
 #'
 #' @param ps phyloseq-class object
 #' @param subgroup_level string of smaller taxonomic group
+#' @param as_relative_abundance transform counts to relative abundance
 #'
 #' @import dplyr
 #'

--- a/R/color_mapping_functions.R
+++ b/R/color_mapping_functions.R
@@ -226,7 +226,7 @@ create_color_dfs <- function(mdf,
 
     # Rename missing genera
     mdf_unknown_subgroup <- mdf %>%
-        mutate(!!sym (subgroup_level) := fct_explicit_na(!!sym(subgroup_level), "Unknown"))
+        mutate(!!sym (subgroup_level) := fct_na_value_to_level(!!sym(subgroup_level), "Unknown"))
 
     # Rank group-subgroup categories by ranked abundance and add order
     # Ranked abundance aggregated using sum() function

--- a/R/custom_legend.R
+++ b/R/custom_legend.R
@@ -100,7 +100,7 @@ individual_legend <- function (mdf,
   select_cdf <- cdf %>% filter(!!sym(col_name_group) == group_name)
 
   select_plot <- ggplot(select_mdf,
-    aes_string(x = x, y = y, fill = col_name_subgroup, text = col_name_subgroup)) +
+    aes(x = .data[[x]], y = .data[[y]], fill = .data[[col_name_subgroup]], text = .data[[col_name_subgroup]])) +
     geom_col( position="fill") +
     scale_fill_manual(name = group_name,
                       values = select_cdf$hex,

--- a/R/plot_functions.R
+++ b/R/plot_functions.R
@@ -46,7 +46,7 @@ plot_microshades <- function (mdf_group,
 
 
   plot <- mdf_group %>%
-    ggplot(aes_string(x = x, y = y), fill = group_label) +
+    ggplot(aes(x = .data[[x]], y = .data[[y]]), fill = group_label) +
     scale_fill_manual(name = group_label,
                       values = cdf$hex,
                       breaks = cdf$group) +
@@ -131,7 +131,7 @@ plot_contributions <- function(mdf, cdf,  col_name, data_match, short_name = NUL
   }
 
   # Boxplot
-  top_drivers_boxplot <- ggplot(cluster_subset, aes_string(x = short_name, y = "Abundance", fill = "group")) +
+   top_drivers_boxplot <- ggplot(cluster_subset, aes(x = .data[[short_name]], y = .data[["Abundance"]], fill = .data[["group"]])) +
     geom_boxplot() +
     coord_flip() +
     ggtitle(paste(col_name, data_match, "(n =",n_samples,")")) +
@@ -140,7 +140,7 @@ plot_contributions <- function(mdf, cdf,  col_name, data_match, short_name = NUL
     theme(legend.position = "none")
 
   # Mean Barplot
-  top_drivers_mean_barplot <- ggplot(cluster_subset_barplot, aes_string(x = short_name, y = "mean_abundance", fill = "group")) +
+  top_drivers_mean_barplot <- ggplot(cluster_subset_barplot, aes(x = .data[[short_name]], y = .data[["mean_abundance"]], fill = .data[["group"]])) +
     geom_bar(stat = "identity") +
     coord_flip() +
     ggtitle(paste(col_name, data_match, "(n =",n_samples,")")) +
@@ -149,7 +149,7 @@ plot_contributions <- function(mdf, cdf,  col_name, data_match, short_name = NUL
     theme(legend.position = "none")
 
   # Median Barplot
-  top_drivers_median_barplot <- ggplot(cluster_subset_barplot, aes_string(x = short_name, y = "median_abundance", fill = "group")) +
+  top_drivers_median_barplot <- ggplot(cluster_subset_barplot, aes(x = .data[[short_name]], y = .data[["mean_abundance"]], fill = .data[["group"]])) +
     geom_bar(stat = "identity") +
     coord_flip() +
     ggtitle(paste(col_name, data_match, "(n =",n_samples,")")) +

--- a/vignettes/microshades-GP.Rmd
+++ b/vignettes/microshades-GP.Rmd
@@ -27,6 +27,7 @@ library(dplyr)
 library(cowplot)
 library(patchwork)
 library(forcats)
+library(tidyverse)
 
 # The dataset Global Patterns is a phyloseq object avalible from the Phyloseq package
 data(GlobalPatterns)

--- a/vignettes/microshades-GP.Rmd
+++ b/vignettes/microshades-GP.Rmd
@@ -26,6 +26,7 @@ library(ggplot2)
 library(dplyr)
 library(cowplot)
 library(patchwork)
+library(forcats)
 
 # The dataset Global Patterns is a phyloseq object avalible from the Phyloseq package
 data(GlobalPatterns)

--- a/vignettes/microshades-HMP.Rmd
+++ b/vignettes/microshades-HMP.Rmd
@@ -31,6 +31,7 @@ library(phyloseq)
 library(dplyr)
 library(ggplot2)
 library(microshades)
+library(forcats)
 ```
 
 ## Load and subset the HMP data

--- a/vignettes/microshades-HMP.Rmd
+++ b/vignettes/microshades-HMP.Rmd
@@ -32,6 +32,7 @@ library(dplyr)
 library(ggplot2)
 library(microshades)
 library(forcats)
+library(tidyverse)
 ```
 
 ## Load and subset the HMP data

--- a/vignettes/microshades-HMP2.Rmd
+++ b/vignettes/microshades-HMP2.Rmd
@@ -33,7 +33,8 @@ library(MultiAssayExperiment)
 library(dplyr)
 library(ggplot2)
 library(microshades)
-libray(forcats)
+library(forcats)
+library(tidyverse)
 ```
 
 ## Load the HMP2 data as a phyloseq object

--- a/vignettes/microshades-HMP2.Rmd
+++ b/vignettes/microshades-HMP2.Rmd
@@ -33,6 +33,7 @@ library(MultiAssayExperiment)
 library(dplyr)
 library(ggplot2)
 library(microshades)
+libray(forcats)
 ```
 
 ## Load the HMP2 data as a phyloseq object


### PR DESCRIPTION
Hello! Here is an overview of the changes proposed in this pull request:

# Changes proposed

## 1) Replace use of the deprecated function `fct_explicit_na`. 
*Why*: Updating R results in an deprecated function error where `fct_explicit_na` is used, as documented in #19. 

*Fix*: Replace `fct_explicit_na` with `fct_na_value_to_level`.

## 2) Replace use of the deprecated function `aes_string`.
*Why*: `aes_string` was deprecated in a recent version of `ggplot`. 

*Fix*: Use the `.data` pronoun in the `aes` function where the aesthetics are specified in `ggplot` commands in the plot and legend functions.

## 3) Fix problems with use of external vectors in selecting functions.
*Why*: Using an external vector in selections was deprecated in a recent version of `tidyselect`.

*Fix*: Use `all_of` where vectors are used in the`select` function; replace input in the `group_by_at` function with a character vector of column names.

## 4) Update package dependencies in vignettes. 
*Why*: Packages `forcats` and `tidyverse` are required to be loaded in order for the Global Patterns Data and Human Microbiome Project 1 & 2 vignettes to run.

*Fix:* Add the necessary package load commands in the vignettes that require them.

- - -

Additionally: add a param comment to document recently added as_relative_abundance parameter in the `prep_mdf` function.

# Checks

- [x] Vignettes result in the same output with no changes.
- [x] No new warnings or errors have been generated.

Thank you!

Best,
Anagha